### PR TITLE
Allow for renaming exposed methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ The use of the `expose` method has the added advantage of clearly identifying wh
 
 The method `private_method` is never accessible in the DSL or as part of the public API.
 
+The _name_ the exposed method is exposed _as_, can be overridden by passing a second argument to `expose`:
+
+```ruby
+class MyDSL
+  include Cleanroom
+
+  attr_accessor :name
+
+  expose :name=, :name
+end
+```
+
 ### Evaluating DSLs
 The cleanroom also includes the ability to more safely evaluate DSL files. Given an instance of a class, you can call `evaluate` or `evaluate_file` to read a DSL.
 

--- a/lib/cleanroom.rb
+++ b/lib/cleanroom.rb
@@ -75,12 +75,12 @@ module Cleanroom
     #
     # @param [Symbol] name
     #
-    def expose(name)
+    def expose(name, exposed_name = name)
       unless public_method_defined?(name)
         raise NameError, "undefined method `#{name}' for class `#{self.name}'"
       end
 
-      exposed_methods[name] = true
+      exposed_methods[exposed_name] = name
     end
 
     #
@@ -101,7 +101,7 @@ module Cleanroom
     # @return [Class]
     #
     def cleanroom
-      exposed = exposed_methods.keys
+      exposed = exposed_methods
       parent = self.name || 'Anonymous'
 
       Class.new(Object) do
@@ -125,8 +125,8 @@ module Cleanroom
           end
         end
 
-        exposed.each do |exposed_method|
-          define_method(exposed_method) do |*args, &block|
+        exposed.each do |exposed_name, exposed_method|
+          define_method(exposed_name) do |*args, &block|
             __instance__.public_send(exposed_method, *args, &block)
           end
         end

--- a/lib/cleanroom.rb
+++ b/lib/cleanroom.rb
@@ -74,6 +74,9 @@ module Cleanroom
     # Expose the given method to the DSL.
     #
     # @param [Symbol] name
+    #   the name of the method to be exposed
+    # @param [Symbol] exposed_name
+    #   the name the exposed method is exposed as
     #
     def expose(name, exposed_name = name)
       unless public_method_defined?(name)

--- a/spec/unit/cleanroom_spec.rb
+++ b/spec/unit/cleanroom_spec.rb
@@ -124,12 +124,21 @@ describe Cleanroom do
       expect { klass.expose(:no_method) }.to raise_error(NameError)
     end
 
+    it 'exposes a public method with a new name' do
+      expect { klass.expose(:public_method, :renamed_public_method) }.to_not raise_error
+      expect(klass.exposed_methods).to include(:renamed_public_method)
+    end
+
     it 'raises an exception if the method is protected' do
       expect { klass.expose(:protected_method) }.to raise_error(NameError)
     end
 
     it 'raises an exception if the method is private' do
       expect { klass.expose(:private_method) }.to raise_error(NameError)
+    end
+
+    it 'raises an exception if the method is private and renamed' do
+      expect { klass.expose(:private_method, :renamed_private_method) }.to raise_error(NameError)
     end
   end
 


### PR DESCRIPTION
This makes it easier to expose writers (`name=`):

```
class A
  include Cleanroom
  attr_accessor :name
  expose :name=, :name
end
```

such that in the DSL you can use `name "Elmo"` to set the name.

Does this make sense? If so, I'd add tests and documentation.
